### PR TITLE
Update for 0.6.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all    :; SOLC_FLAGS="--optimize --optimize-runs=1000000" dapp --use solc:0.6.11 build --extract
+all    :; DAPP_BUILD_OPTIMIZE=1 DAPP_BUILD_OPTIMIZE_RUNS=1000000 dapp --use solc:0.6.12 build --extract
 clean  :; dapp clean
 test   :; ./test-autoexec.sh
-deploy :; SOLC_FLAGS="--optimize --optimize-runs=1000000" dapp --use solc:0.6.11 build && dapp create Autoexec
+deploy :; make && dapp create Autoexec

--- a/src/Autoexec.sol
+++ b/src/Autoexec.sol
@@ -31,9 +31,9 @@ interface IlkReg {
 
 contract Autoexec {
 
-    Chainlog constant  cl = Chainlog(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
-    IlkReg   immutable ir;
-    AutoLine immutable al;
+    Chainlog private constant  cl = Chainlog(0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F);
+    IlkReg   private immutable ir;
+    AutoLine private immutable al;
 
     constructor() public {
         ir = IlkReg(cl.getAddress("ILK_REGISTRY"));
@@ -45,5 +45,13 @@ contract Autoexec {
         for (uint256 i = 0; i < _ilks.length; i++) {
             al.exec(_ilks[i]);
         }
+    }
+
+    function registry() external view returns (address) {
+        return address(ir);
+    }
+
+    function autoline() external view returns (address) {
+        return address(al);
     }
 }

--- a/src/Autoexec.sol
+++ b/src/Autoexec.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later
 /// Autoexec.sol -- Adjust the DC IAM for all MCD collateral types
 
 // Copyright (C) 2020  Brian McMichael
@@ -15,7 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-pragma solidity ^0.6.11;
+pragma solidity ^0.6.12;
 
 interface Chainlog {
     function getAddress(bytes32) external returns (address);

--- a/test-autoexec.sh
+++ b/test-autoexec.sh
@@ -3,7 +3,10 @@ set -e
 
 [[ "$ETH_RPC_URL" && "$(seth chain)" == "ethlive" ]] || { echo "Please set a mainnet ETH_RPC_URL"; exit 1; }
 
-SOLC_FLAGS="--optimize --optimize-runs=1000000" dapp --use solc:0.6.11 build
+export DAPP_BUILD_OPTIMIZE=1
+export DAPP_BUILD_OPTIMIZE_RUNS=1000000
+export SOLC_FLAGS="--optimize --optimize-runs=1000000"
+dapp --use solc:0.6.12 build
 
 export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)


### PR DESCRIPTION
Originally planned ilk-registry 2.0 update and utilize new dapptools flag.

Current autoexec would work fine with a redeploy, but we should bump the version when we do.